### PR TITLE
net: rtwifi: Utilise CONFIG_RTWIFI and friends to allow compilation of the driver.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-obj-$(CONFIG_RTL8XXXU)	+= rtwifi.o
+obj-$(CONFIG_RTWIFI)	+= rtwifi.o
 
 rtwifi-y	:= rtl8xxxu_core.o rtl8xxxu_8192e.o rtl8xxxu_8723b.o \
 		   rtl8xxxu_8723a.o rtl8xxxu_8192c.o rtl8xxxu_8188e.o

--- a/rtl8xxxu_8192c.c
+++ b/rtl8xxxu_8192c.c
@@ -40,7 +40,7 @@
 #include "rtl8xxxu.h"
 #include "rtl8xxxu_regs.h"
 
-#ifdef CONFIG_RTL8XXXU_EXPERIMENTAL
+#ifdef CONFIG_RTWIFI_EXPERIMENTAL
 static struct rtl8xxxu_power_base rtl8192c_power_base = {
 	.reg_0e00 = 0x07090c0c,
 	.reg_0e04 = 0x01020405,


### PR DESCRIPTION
Previously, we had switched to the new configs but there were some
references to the old configs that had not been changed.

Signed-off-by: Diab Neiroukh <lazerl0rd@thezest.dev>